### PR TITLE
bug where modal auto opens and close button doesn't work

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ export default class ModalPicker extends BaseComponent {
         );
 
         this.state = {
-            modalVisible: null,
+            modalVisible: false,
             transparent: false,
             selected: 'please select'
         };
@@ -140,7 +140,7 @@ export default class ModalPicker extends BaseComponent {
                     </ScrollView>
                 </View>
                 <View style={styles.cancelContainer}>
-                    <TouchableOpacity onPress={() => {onClose && onClose(); this.close}}>
+                    <TouchableOpacity onPress={() => {onClose && onClose(); this.close()}}>
                         <View style={[styles.cancelStyle, this.props.cancelStyle]}>
                             <Text style={[styles.cancelTextStyle,this.props.cancelTextStyle]}>{this.props.cancelText}</Text>
                         </View>


### PR DESCRIPTION
- add parenthesis to close function call on cancel
- make default of `modalVisible` state to be false vs. null (null seems to trigger the modal to open when the component is rendered on the newest react-native version `0.47.2)
    - didn't test lower version of react-native